### PR TITLE
Ensure correct SCM URL is used

### DIFF
--- a/roles/common/tasks/main.yaml
+++ b/roles/common/tasks/main.yaml
@@ -4,9 +4,10 @@
   set_fact:
     demo_hosting_api_fqdn: "{{ demo_hosting_api_fqdn }}"
     demo_projectname: "{{ demo_projectname }}"
-    demo_scm_url: "{{ demo_scm_url }}"
     demo_username: "{{ demo_username }}" 
     demo_token: "{{ demo_token }}" 
+    scm_url: "{{ demo_scm_url | regex_replace('^([^#]+)#?.*', '\\1') }}"
+    scm_ref: "{{ demo_scm_url | regex_replace('^[^#]+#?(.*)$', '\\1') }}"
 
 - name: "Use a unique temporary file to store the git source"
   tempfile:

--- a/roles/make-demo-unique/tasks/namespace.yml
+++ b/roles/make-demo-unique/tasks/namespace.yml
@@ -6,6 +6,11 @@
       value: "{{ unique_name }}"
     - match: 'NAMESPACE_DESCRIPTION'
       value: "{{ unique_name }}"
+    scm_replacement_values:
+    - match: 'SCM_URL'
+      value: "{{ scm_url }}"
+    - match: 'SCM_REF'
+      value: "{{ scm_ref }}"
 
 - name: "Append the demo projectname in the params files"
   replace:
@@ -28,4 +33,16 @@
   loop_control:
     loop_var: content 
 
+- name: "Update SCM related config to ensure it's pointing to the correct source repo, etc."
+  replace:
+    path: "{{ content.0.params }}"
+    regexp: '^({{ content.1.match }})=.*$'
+    replace: '\1={{ content.1.value }}'
+  with_nested:
+  - "{{ item.content }}"
+  - "{{ scm_replacement_values }}"
+  when:
+  - content.1.value|trim != ''
+  loop_control:
+    loop_var: content
 

--- a/roles/scm-clone/tasks/main.yml
+++ b/roles/scm-clone/tasks/main.yml
@@ -2,5 +2,6 @@
 
 - name: "Checkout the demo git source"
   git: 
-    repo: "{{ demo_scm_url }}" 
+    repo: "{{ scm_url }}" 
+    version: "{{ (scm_ref|trim == '') | ternary('HEAD', scm_ref) }}"
     dest: "{{ demo_src_tree }}"


### PR DESCRIPTION
This PR takes care of updating the SCM_URL (and SCM_REF) to ensure the build configs, etc. within OpenShift points to the correct repo. 

Note: This means the templates *has to* use the keywords `SCM_URL` and `SCM_REF` for the tools to work correctly. 