### PR TITLE
Updating 'openshift-applier' to the v2.0.2 version

### DIFF
--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -1,8 +1,8 @@
 
 # From: 'openshift-applier'
 - src: https://github.com/redhat-cop/openshift-applier
-  version: v2.0.0
+  version: v2.0.2
 
 # From: 'casl-ansible'
 - src: https://github.com/redhat-cop/casl-ansible
-  version: v3.9.2
+  version: v3.10.1


### PR DESCRIPTION
@tylerauerbeck updating the `openshift-applier` to the latest `v2.0.2` release  + CASL to `v3.10.1` (depending on a new CASL release being cut today). 