### PR TITLE
Updating the requirements to use recent tags

### DIFF
--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -1,8 +1,8 @@
 
 # From: 'openshift-applier'
 - src: https://github.com/redhat-cop/openshift-applier
-  version: v2.0.2
+  version: v2.1.2
 
 # From: 'casl-ansible'
 - src: https://github.com/redhat-cop/casl-ansible
-  version: v3.10.1
+  version: v3.11.5


### PR DESCRIPTION
### What does this PR do?
This PR updates the requirements file to use the most recent tag version of openshift-applier and casl-ansible, which is required for the Infographic app to work with Ansible Tower 3.6.3-1.

### How should this be tested?
By deploying Tower 3.6.3-1 and kicking off the 'run-demo.yml' playbook.

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @rht-labs/labs-demo