### PR TITLE
Updating paths to work with Tower 3.6

### DIFF
--- a/playbooks/run-demo.yml
+++ b/playbooks/run-demo.yml
@@ -15,8 +15,8 @@
   - openshift_token: "{{ demo_token }}"
   roles:
   - role: common
-  - role: ../roles/casl-ansible/roles/openshift-defaults
-  - role: ../roles/casl-ansible/roles/openshift-login
+  - role: casl-ansible/roles/openshift-defaults
+  - role: casl-ansible/roles/openshift-login
 
 - name: "Prepare the SCM for use with this demo env"
   hosts: seed-hosts
@@ -38,7 +38,7 @@
   vars:
     openshift_user: "{{ demo_username }}"
     openshift_token: "{{ demo_token }}"
-  import_playbook: ../roles/openshift-applier/playbooks/openshift-cluster-seed.yml
+  import_playbook: ../../requirements_roles/openshift-applier/playbooks/openshift-cluster-seed.yml
 
 - name: "Demo prep clean-up"
   hosts: seed-hosts


### PR DESCRIPTION
### What does this PR do?
This PR updates the paths required for Ansible Tower 3.6.x to be able to access and process the additional playbooks and roles necessary to successfully execute the run-demo.yml playbook without interruption.

According to the tests I performed, Ansible Tower 3.6.x moves the content fetched from the Git repository to a temporary directory - usually within `/tmp/random-tempdir` - that gets created during the execution of a job, and that gets deleted afterwards.

Additionally, during the tests, I observed that if a `requirements.yml` file is specified, Ansible Tower installs it in `/tmp/tempdir/requirements_roles/` and expects the dependencies to be reached from that base directory.

These changes are not compatible with Ansible Tower version 3.5.x and lower.

### How should this be tested?
By deploying Tower 3.6.3-1 and kicking off the 'run-demo.yml' playbook and watching the Jobs section of Ansible Tower, however, this output can only be seen if the Connection Debug (-vvvv) is sepcified in the Job configuration.

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A

### People to notify
cc: @rht-labs/labs-demo