### PR TITLE
CHANGE regexp pattern in task Append the demo projectname in the para…

### DIFF
--- a/roles/make-demo-unique/tasks/namespace.yml
+++ b/roles/make-demo-unique/tasks/namespace.yml
@@ -15,7 +15,7 @@
 - name: "Append the demo projectname in the params files"
   replace:
     path: "{{ content.params }}"
-    regexp: '^(NAMESPACE.*)=(.*)$'
+    regexp: '^(NAMESPACE.*|TARGET_NAMESPACE.*)=(.*)$'
     replace: '\1=\2{{ unique_id }}'
   with_items:
   - "{{ item.content }}"


### PR DESCRIPTION
A small change to make a CRW deployment working.
One of the templates to deploy CRW contains a variable `TARGET_NAMESPACE` which has to be adjusted by a role `make-demo-unique`.